### PR TITLE
appointy/jaal - develop spec compliant GraphQL servers in go

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Main site: http://graphql.org/
 - [Python](https://github.com/dittos/graphql-py)
 - [Scala](https://github.com/sangria-graphql/sangria)
 - [.NET](https://github.com/joemcbride/graphql-dotnet)
+- [Go](https://github.com/appointy/jaal)
 
 ## Example Implementations
 


### PR DESCRIPTION
[Jaal](https://github.com/appointy/jaal)

Jaal is GraphQL Server library written in Go. It can be used to develop spec-compliant GraphQL servers in Go.
